### PR TITLE
feat(map): add a loadTile to the object returned by getSource()

### DIFF
--- a/classes/map.js
+++ b/classes/map.js
@@ -83,7 +83,8 @@ Map.prototype.getSource = function(name) {
     return {
       setData: function(data) {
         this._sources[name].data = data;
-      }.bind(this)
+      }.bind(this),
+      loadTile: function() {}
     };
   }
 };


### PR DESCRIPTION
I know `loadTile` is not part of the public API of a raster source. But we are overwriting it from the outside to only load tiles in a given bounding box:

```js
  const source = map.getSource(id);
  const originalLoadTile = source.loadTile.bind(source);

  source.loadTile = (tile, callback) => {
    const intersects = testTileIntersection(boundingBox, tile);

    if (intersects) {
      return originalLoadTile(tile, callback);
    }

    return callback(null);
  };
```

We just need the property on the object. Shouldn't hurt anyone.