### PR TITLE
Lock in Jsdom @ 11.11.0 to prevent localStorage error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@turf/union": "^5.0.4",
     "flow-remove-types": "^1.2.3",
     "gl": "^4.0.4",
-    "jsdom": "^11.6.2",
+    "jsdom": "11.11.0",
     "mapbox-gl": "^0.44.1",
     "sinon": "^4.3.0"
   },


### PR DESCRIPTION
Reference:
https://github.com/mapbox/mapbox-gl-js/pull/7455

mapbox-gl-js-mock is bumping the jsdom to the latest version which leads to an unnecessary localStorage error.